### PR TITLE
Automatically host on startup

### DIFF
--- a/server/src/mindustry/server/ServerControl.java
+++ b/server/src/mindustry/server/ServerControl.java
@@ -124,6 +124,7 @@ public class ServerControl implements ApplicationListener{
             }
 
             Seq<String> commands = new Seq<>();
+            commands.add("host");
 
             if(args.length > 0){
                 commands.addAll(Strings.join(" ", args).split(","));


### PR DESCRIPTION
Runs the host command as soon as the server starts so it doesnt shut down instantly when running `gradlew server:run`