### PR TITLE
Properly render foreshadow bullets

### DIFF
--- a/core/src/mindustry/world/blocks/defense/turrets/Turret.java
+++ b/core/src/mindustry/world/blocks/defense/turrets/Turret.java
@@ -446,7 +446,8 @@ public class Turret extends ReloadTurret{
         protected void bullet(BulletType type, float angle){
             float lifeScl = type.scaleVelocity ? Mathf.clamp(Mathf.dst(x + tr.x, y + tr.y, targetPos.x, targetPos.y) / type.range(), minRange / type.range(), range / type.range()) : 1f;
 
-            type.create(this, team, x + tr.x, y + tr.y, angle, 1f + Mathf.range(velocityInaccuracy), lifeScl);
+            if(block == Blocks.foreshadow) type.createNet(team, x + tr.x, y + tr.y, angle, -1, 1f + Mathf.range(velocityInaccuracy), lifeScl); // Custom foreshadow bullet
+            else type.create(this, team, x + tr.x, y + tr.y, angle, 1f + Mathf.range(velocityInaccuracy), lifeScl);
         }
 
         protected void effects(){


### PR DESCRIPTION
This is a minor tweak to make foreshadow bullets draw "properly". Its kinda janky because it seemingly double fires but I think its better?
[Before](https://mee6.is-terrible.com/53UnDWS93.webm)
[After](https://mee6.is-terrible.com/53UmZ8kUb.webm)